### PR TITLE
Add directory and plugin attrs

### DIFF
--- a/lib/kitchen/pulumi/config_attribute/directory.rb
+++ b/lib/kitchen/pulumi/config_attribute/directory.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi'
+require 'kitchen/pulumi/config_schemas/string'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/file_path_config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Attribute used to specify the directory containing a project's
+      # Pulumi.yaml file
+      module Directory
+        def self.included(plugin_class)
+          definer = FilePathConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::String,
+          )
+          definer.definer(plugin_class: plugin_class)
+        end
+
+        def self.to_sym
+          :directory
+        end
+
+        extend config_attribute_cacher
+
+        def config_directory_default_value
+          '.'
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/pulumi/config_attribute/plugins.rb
+++ b/lib/kitchen/pulumi/config_attribute/plugins.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi/config_attribute'
+require 'kitchen/pulumi/config_schemas/array_of_hashes'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Module used for specifying any required plugins that a project
+      # will need to provision its resources.
+      module Plugins
+        def self.included(plugin)
+          definer = ConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::ArrayOfHashes,
+          )
+          definer.define(plugin_class: plugin)
+        end
+
+        def self.to_sym
+          :plugins
+        end
+
+        extend ConfigAttributeCacher
+
+        def config_plugins_default_value
+          []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Changes
* Adds 2 config attributes: `directory` and `plugins`:
  * `directory` will be a string specifying a relative path to the directory containing the project's `Pulumi.yaml` file
     * This will most likely be used as the value for the `--cwd <directory>` flag in all Pulumi CLI commands
  * `plugins` will be an array of hashes which describe any plugins to install that the project depends on.
    * At `kitchen create` time, these plugins will be dowloaded by shelling out to the Pulumi CLI
```
pulumi plugin install [KIND NAME VERSION] [--file <file>] [--cloud-url <url>]
```

##### Example driver configuration (with a config override on the aws plugin)
```yaml
driver:
  name: pulumi
  directory: infra
  plugins:
    - kind: resource
      name: aws
      version: 0.14.2
    - file: plugins/my-local-plugin.tar.gz
  config:
    - aws:
       - key: region
         value: us-west-2
```