### PR TITLE
Implement basic driver features with stack initialization and configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,33 @@
-version: 2
-jobs:
-   build:
-    docker:
-      - image: circleci/ruby:2.4.1-node-browsers
+version: 2.1
 
+orbs:
+  pulumi: pulumi/pulumi@1.0.0
+
+jobs:
+  build_24: &build
+    docker:
+      - image: circleci/ruby:2.4.6
     steps:
       - checkout
+
+      # Ensure Pulumi CLI is available for use
+      - pulumi/login
+
+      # Install dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "Gemfile.lock" }}
-            - v1-dependencies
+            - kitchen-pulumi-dependencies-{{ checksum "Gemfile.lock" }}
+            - kitchen-pulumi-dependencies
       - run: bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           paths:
             - vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: kitchen-pulumi-dependencies-{{ checksum "Gemfile.lock" }}
 
+      # Lint
       - run: bundle exec rake lint
 
+      # Run unit tests
       - run: mkdir /tmp/test-results && bundle exec rake spec
       - store_test_results:
           path: /tmp/test-results
@@ -25,8 +35,20 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
+  build_25:
+    <<: *build
+    docker:
+      - image: circleci/ruby:2.5.5
+
+  build_26:
+    <<: *build
+    docker:
+      - image: circleci/ruby:2.6.2
+
+
 workflows:
-  version: 2
   build:
     jobs:
-      - build
+      - build_24
+      - build_25
+      - build_26

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.kitchen/
+
 *.gem
 *.rbc
 /.config

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,13 @@
 ---
 AllCops:
   TargetRubyVersion: 2.4
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
+Metrics/MethodLength:
+  Max: 15
+Metrics/AbcSize:
+  Max: 16

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArrayLiteral:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,5 +9,3 @@ Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 Metrics/MethodLength:
   Max: 15
-Metrics/AbcSize:
-  Max: 16

--- a/Rakefile
+++ b/Rakefile
@@ -14,3 +14,9 @@ RSpec::Core::RakeTask.new(:spec) do |t|
     --out /tmp/test-results/rspec.xml
   ARGS
 end
+
+desc 'Integration tests'
+task :integration_test do
+  Dir.chdir('spec/support/test-project')
+  sh 'bundle exec kitchen create'
+end

--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -45,6 +45,23 @@ module Kitchen
           puts 'Continuing...'
         end
       end
+
+      def configure(stack:, dir: '.')
+        config_config.each do |namespace|
+          ns = namespace.keys.first
+          config_items = namespace.fetch(ns)
+
+          config_items.each do |config_item|
+            key = config_item.fetch(:key, '')
+            val = config_item.fetch(:value, '')
+
+            ::Kitchen::Pulumi::ShellOut.run(
+              cmd: "config set #{ns}:#{key} #{val} -s #{stack} #{dir}",
+              logger: logger,
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -27,15 +27,21 @@ module Kitchen
       include ::Kitchen::Pulumi::ConfigAttribute::Stack
 
       def create(_state)
+        dir = "-C #{config_directory}"
         stack = config_stack.empty? ? instance.suite.name : config_stack
         ppc = "--ppc #{config_private_cloud}" unless config_private_cloud.empty?
 
+        initialize_stack(stack: stack, ppc: ppc, dir: dir)
+        configure(stack: stack, dir: dir)
+      end
+
+      def initialize_stack(stack:, ppc: '', dir: '.')
         ::Kitchen::Pulumi::ShellOut.run(
-          command: "stack init #{stack} #{ppc} -C #{config_directory}",
+          cmd: "stack init #{stack} #{ppc} #{dir}",
           logger: logger,
         )
-      rescue ::Kitchen::Pulumi::Error => error
-        if error.message.match?(/stack '#{stack}' already exists/)
+      rescue ::Kitchen::Pulumi::Error => e
+        if e.message.match?(/stack '#{stack}' already exists/)
           puts 'Continuing...'
         end
       end

--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'kitchen'
+require 'kitchen/driver/base'
+require 'kitchen/pulumi/error'
+require 'kitchen/pulumi/shell_out'
+require 'kitchen/pulumi/configurable'
+require 'kitchen/pulumi/config_attribute/config'
+require 'kitchen/pulumi/config_attribute/directory'
+require 'kitchen/pulumi/config_attribute/plugins'
+require 'kitchen/pulumi/config_attribute/private_cloud'
+require 'kitchen/pulumi/config_attribute/stack'
+
+class ::Kitchen::Driver::Pulumi < ::Kitchen::Driver::Base
+  kitchen_driver_api_version 2
+
+  include ::Kitchen::Pulumi::Configurable
+
+  # Include config attributes consumable via .kitchen.yml
+  include ::Kitchen::Pulumi::ConfigAttribute::Config
+  include ::Kitchen::Pulumi::ConfigAttribute::Directory
+  include ::Kitchen::Pulumi::ConfigAttribute::Plugins
+  include ::Kitchen::Pulumi::ConfigAttribute::PrivateCloud
+  include ::Kitchen::Pulumi::ConfigAttribute::Stack
+
+  def create(_state)
+    stack = config_stack.empty? ? instance.suite.name : config_stack
+    ppc = "--ppc #{config_private_cloud}" unless config_private_cloud.empty?
+
+    ::Kitchen::Pulumi::ShellOut.run(
+      command: "stack init #{stack} #{ppc} -C #{config_directory}",
+      logger: logger,
+    )
+  rescue ::Kitchen::Pulumi::Error => error
+    if error.message =~ /stack '#{stack}' already exists/
+      puts 'Continuing...'
+    end
+  end
+end

--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -11,29 +11,34 @@ require 'kitchen/pulumi/config_attribute/plugins'
 require 'kitchen/pulumi/config_attribute/private_cloud'
 require 'kitchen/pulumi/config_attribute/stack'
 
-class ::Kitchen::Driver::Pulumi < ::Kitchen::Driver::Base
-  kitchen_driver_api_version 2
+module Kitchen
+  module Driver
+    # Driver class implementing the CLI equivalency between Kitchen and Pulumi
+    class Pulumi < ::Kitchen::Driver::Base
+      kitchen_driver_api_version 2
 
-  include ::Kitchen::Pulumi::Configurable
+      include ::Kitchen::Pulumi::Configurable
 
-  # Include config attributes consumable via .kitchen.yml
-  include ::Kitchen::Pulumi::ConfigAttribute::Config
-  include ::Kitchen::Pulumi::ConfigAttribute::Directory
-  include ::Kitchen::Pulumi::ConfigAttribute::Plugins
-  include ::Kitchen::Pulumi::ConfigAttribute::PrivateCloud
-  include ::Kitchen::Pulumi::ConfigAttribute::Stack
+      # Include config attributes consumable via .kitchen.yml
+      include ::Kitchen::Pulumi::ConfigAttribute::Config
+      include ::Kitchen::Pulumi::ConfigAttribute::Directory
+      include ::Kitchen::Pulumi::ConfigAttribute::Plugins
+      include ::Kitchen::Pulumi::ConfigAttribute::PrivateCloud
+      include ::Kitchen::Pulumi::ConfigAttribute::Stack
 
-  def create(_state)
-    stack = config_stack.empty? ? instance.suite.name : config_stack
-    ppc = "--ppc #{config_private_cloud}" unless config_private_cloud.empty?
+      def create(_state)
+        stack = config_stack.empty? ? instance.suite.name : config_stack
+        ppc = "--ppc #{config_private_cloud}" unless config_private_cloud.empty?
 
-    ::Kitchen::Pulumi::ShellOut.run(
-      command: "stack init #{stack} #{ppc} -C #{config_directory}",
-      logger: logger,
-    )
-  rescue ::Kitchen::Pulumi::Error => error
-    if error.message =~ /stack '#{stack}' already exists/
-      puts 'Continuing...'
+        ::Kitchen::Pulumi::ShellOut.run(
+          command: "stack init #{stack} #{ppc} -C #{config_directory}",
+          logger: logger,
+        )
+      rescue ::Kitchen::Pulumi::Error => error
+        if error.message.match?(/stack '#{stack}' already exists/)
+          puts 'Continuing...'
+        end
+      end
     end
   end
 end

--- a/lib/kitchen/pulumi/config_attribute/directory.rb
+++ b/lib/kitchen/pulumi/config_attribute/directory.rb
@@ -16,14 +16,14 @@ module Kitchen
             attribute: self,
             schema: ConfigSchemas::String,
           )
-          definer.definer(plugin_class: plugin_class)
+          definer.define(plugin_class: plugin_class)
         end
 
         def self.to_sym
           :directory
         end
 
-        extend config_attribute_cacher
+        extend ConfigAttributeCacher
 
         def config_directory_default_value
           '.'

--- a/lib/kitchen/pulumi/config_attribute/private_cloud.rb
+++ b/lib/kitchen/pulumi/config_attribute/private_cloud.rb
@@ -15,14 +15,14 @@ module Kitchen
             attribute: self,
             schema: ConfigSchemas::String,
           )
-          definer.definer(plugin_class: plugin_class)
+          definer.define(plugin_class: plugin_class)
         end
 
         def self.to_sym
           :private_cloud
         end
 
-        extend config_attribute_cacher
+        extend ConfigAttributeCacher
 
         def config_private_cloud_default_value
           ''

--- a/lib/kitchen/pulumi/config_attribute/private_cloud.rb
+++ b/lib/kitchen/pulumi/config_attribute/private_cloud.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi'
+require 'kitchen/pulumi/config_schemas/string'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Attribute used to specify the Pulumi Private Cloud URL for a stack
+      module PrivateCloud
+        def self.included(plugin_class)
+          definer = ConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::String,
+          )
+          definer.definer(plugin_class: plugin_class)
+        end
+
+        def self.to_sym
+          :private_cloud
+        end
+
+        extend config_attribute_cacher
+
+        def config_private_cloud_default_value
+          ''
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/pulumi/config_attribute/stack.rb
+++ b/lib/kitchen/pulumi/config_attribute/stack.rb
@@ -15,14 +15,14 @@ module Kitchen
             attribute: self,
             schema: ConfigSchemas::String,
           )
-          definer.definer(plugin_class: plugin_class)
+          definer.define(plugin_class: plugin_class)
         end
 
         def self.to_sym
           :stack
         end
 
-        extend config_attribute_cacher
+        extend ConfigAttributeCacher
 
         def config_stack_default_value
           ''

--- a/lib/kitchen/pulumi/config_attribute/stack.rb
+++ b/lib/kitchen/pulumi/config_attribute/stack.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi'
+require 'kitchen/pulumi/config_schemas/string'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Attribute used to specify the stack to use for a specific instance
+      module Stack
+        def self.included(plugin_class)
+          definer = ConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::String,
+          )
+          definer.definer(plugin_class: plugin_class)
+        end
+
+        def self.to_sym
+          :stack
+        end
+
+        extend config_attribute_cacher
+
+        def config_stack_default_value
+          ''
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/pulumi/config_schemas/string.rb
+++ b/lib/kitchen/pulumi/config_schemas/string.rb
@@ -6,7 +6,7 @@ require 'kitchen/pulumi/config_schemas'
 module Kitchen
   module Pulumi
     ConfigSchemas::String = ::Dry::Validation.Schema do
-      required(:value).filled :str?
+      required(:value).maybe :str?
     end
   end
 end

--- a/lib/kitchen/pulumi/shell_out.rb
+++ b/lib/kitchen/pulumi/shell_out.rb
@@ -15,8 +15,8 @@ module Kitchen
       rescue ::Errno::EACCES, ::Errno::ENOENT,
              ::Mixlib::ShellOut::InvalidCommandOption,
              ::Mixlib::ShellOut::CommandTimeout,
-             ::Mixlib::ShellOut::ShellCommandFailed => error
-        raise(::Kitchen::Pulumi::Error, "Error: #{error.message}")
+             ::Mixlib::ShellOut::ShellCommandFailed => e
+        raise(::Kitchen::Pulumi::Error, "Error: #{e.message}")
       end
 
       def self.shell_out(command:, duration: 7200, logger:)

--- a/lib/kitchen/pulumi/shell_out.rb
+++ b/lib/kitchen/pulumi/shell_out.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi'
+require 'kitchen/pulumi/error'
+require 'mixlib/shellout'
+
+module Kitchen
+  module Pulumi
+    # Module orchestrating calls to the Pulumi CLI
+    module ShellOut
+      # Shells out to the Pulumi CLI
+      def self.run(command:, duration: 7200, logger:, &block)
+        block ||= ->(stdout) { stdout }
+        shell_out(command: command, duration: duration, logger: logger, &block)
+      rescue ::Errno::EACCES, ::Errno::ENOENT,
+             ::Mixlib::ShellOut::InvalidCommandOption,
+             ::Mixlib::ShellOut::CommandTimeout,
+             ::Mixlib::ShellOut::ShellCommandFailed => error
+        raise(::Kitchen::Pulumi::Error, "Error: #{error.message}")
+      end
+
+      def self.shell_out(command:, duration: 7200, logger:)
+        shell_out = ::Mixlib::ShellOut.new(
+          "pulumi #{command}",
+          live_stream: logger,
+          timeout: duration,
+        )
+
+        logger.warn("Running #{shell_out.command}")
+
+        shell_out.run_command
+        shell_out.error!
+        yield(stdout: shell_out.stdout)
+      end
+    end
+  end
+end

--- a/lib/kitchen/pulumi/shell_out.rb
+++ b/lib/kitchen/pulumi/shell_out.rb
@@ -9,9 +9,9 @@ module Kitchen
     # Module orchestrating calls to the Pulumi CLI
     module ShellOut
       # Shells out to the Pulumi CLI
-      def self.run(command:, duration: 7200, logger:, &block)
+      def self.run(cmd:, duration: 7200, logger:, &block)
         block ||= ->(stdout) { stdout }
-        shell_out(command: command, duration: duration, logger: logger, &block)
+        shell_out(command: cmd, duration: duration, logger: logger, &block)
       rescue ::Errno::EACCES, ::Errno::ENOENT,
              ::Mixlib::ShellOut::InvalidCommandOption,
              ::Mixlib::ShellOut::CommandTimeout,

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -4,20 +4,21 @@ require 'kitchen'
 require 'spec_helper'
 require 'kitchen/driver/pulumi'
 
+# rubocop:disable Metrics/ParameterLists
+# rubocop:disable Metrics/BlockLength
 describe ::Kitchen::Driver::Pulumi do
-
   def kitchen_instance(driver_instance, kitchen_root)
     ::Kitchen::Instance.new(
       driver: driver_instance,
       logger: driver_instance.send(:logger),
       platform: ::Kitchen::Platform.new(name: 'test-platform'),
       provisioner: ::Kitchen::Provisioner::Base.new,
-      suite: ::Kitchen::Suite::new(name: 'test-suite'),
+      suite: ::Kitchen::Suite.new(name: 'test-suite'),
       transport: ::Kitchen::Transport::Base.new,
       verifier: ::Kitchen::Verifier::Base.new,
       state_file: ::Kitchen::StateFile.new(
         kitchen_root,
-        'test-suite-test-platfrom'
+        'test-suite-test-platfrom',
       ),
     )
   end
@@ -54,10 +55,12 @@ describe ::Kitchen::Driver::Pulumi do
 
     it 'should allow overrides of the stack name' do
       in_tmp_project_dir('test-project') do
-        driver = configure_driver(stack: "dev")
+        driver = configure_driver(stack: 'dev')
         expect { driver.create({}) }
           .to output(/Created stack 'dev'/).to_stdout_from_any_process
       end
     end
   end
 end
+# rubocop:enable Metrics/ParameterLists
+# rubocop:enable Metrics/BlockLength

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'kitchen'
+require 'spec_helper'
+require 'kitchen/driver/pulumi'
+
+describe ::Kitchen::Driver::Pulumi do
+
+  def kitchen_instance(driver_instance, kitchen_root)
+    ::Kitchen::Instance.new(
+      driver: driver_instance,
+      logger: driver_instance.send(:logger),
+      platform: ::Kitchen::Platform.new(name: 'test-platform'),
+      provisioner: ::Kitchen::Provisioner::Base.new,
+      suite: ::Kitchen::Suite::new(name: 'test-suite'),
+      transport: ::Kitchen::Transport::Base.new,
+      verifier: ::Kitchen::Verifier::Base.new,
+      state_file: ::Kitchen::StateFile.new(
+        kitchen_root,
+        'test-suite-test-platfrom'
+      ),
+    )
+  end
+
+  def configure_driver(directory: '.',
+                       kitchen_root: '.',
+                       stack: '',
+                       private_cloud: '',
+                       plugins: [],
+                       config: [])
+    config = {
+      kitchen_root: kitchen_root,
+      directory: directory,
+      stack: stack,
+      private_cloud: private_cloud,
+      plugins: plugins,
+      config: config,
+    }
+
+    driver = described_class.new(config)
+    kitchen_instance = kitchen_instance(driver, '.')
+    driver.finalize_config!(kitchen_instance)
+    driver
+  end
+
+  context '#create' do
+    it 'should initialize a stack' do
+      in_tmp_project_dir('test-project') do
+        driver = configure_driver
+        expect { driver.create({}) }
+          .to output(/Created stack 'test-suite'/).to_stdout_from_any_process
+      end
+    end
+
+    it 'should allow overrides of the stack name' do
+      in_tmp_project_dir('test-project') do
+        driver = configure_driver(stack: "dev")
+        expect { driver.create({}) }
+          .to output(/Created stack 'dev'/).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -16,6 +16,7 @@ describe ::Kitchen::Driver::Pulumi do
       suite: ::Kitchen::Suite.new(name: 'test-suite'),
       transport: ::Kitchen::Transport::Base.new,
       verifier: ::Kitchen::Verifier::Base.new,
+      lifecycle_hooks: ::Kitchen::LifecycleHooks.new({}),
       state_file: ::Kitchen::StateFile.new(
         kitchen_root,
         'test-suite-test-platfrom',
@@ -32,7 +33,7 @@ describe ::Kitchen::Driver::Pulumi do
     config = {
       kitchen_root: kitchen_root,
       directory: directory,
-      stack: stack,
+      stack: stack.empty? ? "kitchen-pulumi-test-#{rand(10**10)}" : stack,
       private_cloud: private_cloud,
       plugins: plugins,
       config: config,
@@ -49,15 +50,17 @@ describe ::Kitchen::Driver::Pulumi do
       in_tmp_project_dir('test-project') do
         driver = configure_driver
         expect { driver.create({}) }
-          .to output(/Created stack 'test-suite'/).to_stdout_from_any_process
+          .to output(/Created stack 'kitchen-pulumi-test/)
+          .to_stdout_from_any_process
       end
     end
 
     it 'should allow overrides of the stack name' do
       in_tmp_project_dir('test-project') do
-        driver = configure_driver(stack: 'dev')
+        stack_name = "dev-#{rand(10**10)}"
+        driver = configure_driver(stack: stack_name)
         expect { driver.create({}) }
-          .to output(/Created stack 'dev'/).to_stdout_from_any_process
+          .to output(/Created stack '#{stack_name}'/).to_stdout_from_any_process
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@ def in_tmp_project_dir(support_project_name)
 
   in_tmp_dir do
     FileUtils.cp_r("#{project_dir}/.", Dir.getwd)
-    `pulumi stack ls | awk 'FNR > 1 {print $1}' | xargs -n1 pulumi stack rm -y`
     yield if block_given?
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+def in_tmp_dir
+  Dir.mktmpdir do |dir|
+    Dir.chdir(dir) do
+      yield if block_given?
+    end
+  end
+end
+
+def in_tmp_project_dir(support_project_name)
+  project_dir = File.absolute_path("spec/support/#{support_project_name}")
+
+  in_tmp_dir do
+    FileUtils.cp_r("#{project_dir}/.", Dir.getwd)
+    `pulumi stack ls | awk 'FNR > 1 { print $1 }' | xargs -n1 pulumi stack rm -y`
+    yield if block_given?
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ def in_tmp_project_dir(support_project_name)
 
   in_tmp_dir do
     FileUtils.cp_r("#{project_dir}/.", Dir.getwd)
-    `pulumi stack ls | awk 'FNR > 1 { print $1 }' | xargs -n1 pulumi stack rm -y`
+    `pulumi stack ls | awk 'FNR > 1 {print $1}' | xargs -n1 pulumi stack rm -y`
     yield if block_given?
   end
 end

--- a/spec/support/test-project/.kitchen.yml
+++ b/spec/support/test-project/.kitchen.yml
@@ -1,0 +1,23 @@
+---
+driver:
+  name: pulumi
+
+suites:
+  - name: test-project-dev-west
+    driver:
+      stack: kitchen
+      config:
+        - aws:
+          - key: region
+            value: us-west-2
+
+  - name: test-project-dev-east
+    driver:
+      stack: kitchen
+      config:
+        - aws:
+          - key: region
+            value: us-east-1
+
+platforms:
+  - name: default

--- a/spec/support/test-project/.kitchen.yml
+++ b/spec/support/test-project/.kitchen.yml
@@ -5,16 +5,22 @@ driver:
 suites:
   - name: test-project-dev-west
     driver:
-      stack: kitchen
+      stack: dev-west
       config:
+        - test-project:
+          - key: bucket_name
+            value: kitchen-pulumi-8009408424
         - aws:
           - key: region
             value: us-west-2
 
   - name: test-project-dev-east
     driver:
-      stack: kitchen
+      stack: dev-east
       config:
+        - test-project:
+          - key: bucket_name
+            value: kitchen-pulumi-9089332077
         - aws:
           - key: region
             value: us-east-1

--- a/spec/support/test-project/Pulumi.dev-east.yaml
+++ b/spec/support/test-project/Pulumi.dev-east.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: us-east-1
+  test-project:bucket_name: kitchen-pulumi-1

--- a/spec/support/test-project/Pulumi.dev-east.yaml
+++ b/spec/support/test-project/Pulumi.dev-east.yaml
@@ -1,3 +1,3 @@
 config:
   aws:region: us-east-1
-  test-project:bucket_name: kitchen-pulumi-1
+  test-project:bucket_name: kitchen-pulumi-9089332077

--- a/spec/support/test-project/Pulumi.dev-west.yaml
+++ b/spec/support/test-project/Pulumi.dev-west.yaml
@@ -1,3 +1,3 @@
 config:
   aws:region: us-west-2
-  test-project:bucket_name: kitchen-pulumi-5
+  test-project:bucket_name: kitchen-pulumi-8009408424

--- a/spec/support/test-project/Pulumi.dev-west.yaml
+++ b/spec/support/test-project/Pulumi.dev-west.yaml
@@ -1,0 +1,3 @@
+config:
+  aws:region: us-west-2
+  test-project:bucket_name: kitchen-pulumi-5

--- a/spec/support/test-project/Pulumi.test-project-dev.yaml
+++ b/spec/support/test-project/Pulumi.test-project-dev.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: us-east-1

--- a/spec/support/test-project/Pulumi.yaml
+++ b/spec/support/test-project/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-project
+description: test project for kitchen-pulumi
+runtime: python

--- a/spec/support/test-project/__main__.py
+++ b/spec/support/test-project/__main__.py
@@ -1,8 +1,11 @@
 import pulumi
 from pulumi_aws import s3
 
+config = pulumi.Config('test-project')
+bucket_name = config.require('bucket_name')
+
 # Create an AWS resource (S3 Bucket)
-bucket = s3.Bucket('my-bucket')
+bucket = s3.Bucket(bucket_name)
 
 # Export the DNS name of the bucket
 pulumi.output('bucket_name',  bucket.bucket_domain_name)

--- a/spec/support/test-project/__main__.py
+++ b/spec/support/test-project/__main__.py
@@ -1,0 +1,8 @@
+import pulumi
+from pulumi_aws import s3
+
+# Create an AWS resource (S3 Bucket)
+bucket = s3.Bucket('my-bucket')
+
+# Export the DNS name of the bucket
+pulumi.output('bucket_name',  bucket.bucket_domain_name)

--- a/spec/support/test-project/requirements.txt
+++ b/spec/support/test-project/requirements.txt
@@ -1,0 +1,2 @@
+pulumi>=0.14.0
+pulumi_aws>=0.14.0


### PR DESCRIPTION
#### Changes
* Implements the driver's `create` method called on `kitchen create` to initialize a stack and configure it according to the local project and a user's `config` map defined on the kitchen instance
* Tests ruby 2.4, 2.5, and 2.6 in CircleCI and uses the Pulumi orb
* Adds basic unit tests and integration tests