### PR TITLE
Add refresh_config option to driver to force local stack config refresh before updates

### DIFF
--- a/lib/kitchen/pulumi/config_attribute/refresh_config.rb
+++ b/lib/kitchen/pulumi/config_attribute/refresh_config.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi'
+require 'kitchen/pulumi/config_schemas/boolean'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Attribute used to determine if the stack config should be
+      # refreshed from the remote before every `pulumi up` command
+      module RefreshConfig
+        def self.included(plugin_class)
+          definer = ConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::Boolean,
+          )
+          definer.define(plugin_class: plugin_class)
+        end
+
+        def self.to_sym
+          :refresh_config
+        end
+
+        extend ConfigAttributeCacher
+
+        def config_refresh_config_default_value
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/pulumi/config_schemas/boolean.rb
+++ b/lib/kitchen/pulumi/config_schemas/boolean.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'dry-validation'
+require 'kitchen/pulumi/config_schemas'
+
+module Kitchen
+  module Pulumi
+    ConfigSchemas::Boolean = ::Dry::Validation.Schema do
+      required(:value).maybe :bool?
+    end
+  end
+end

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -34,7 +34,8 @@ describe ::Kitchen::Driver::Pulumi do
                        plugins: [],
                        config: {},
                        config_file: '',
-                       secrets: {})
+                       secrets: {},
+                       refresh_config: false)
     driver_config = {
       kitchen_root: kitchen_root,
       directory: directory,
@@ -44,6 +45,7 @@ describe ::Kitchen::Driver::Pulumi do
       config: config,
       config_file: config_file,
       secrets: secrets,
+      refresh_config: refresh_config,
     }
 
     driver = described_class.new(driver_config)
@@ -119,6 +121,7 @@ describe ::Kitchen::Driver::Pulumi do
           config: config,
           config_file: config_file,
           secrets: secrets,
+          refresh_config: true,
         )
 
         expected = expect do

--- a/spec/support/test-project/.kitchen.yml
+++ b/spec/support/test-project/.kitchen.yml
@@ -11,6 +11,7 @@ suites:
       backend: local
       stack: <%= "dev-west-#{rand(10**10)}" %>
       config_file: custom-stack-config-file.yaml
+      refresh_config: true
       config:
         test-project:
           foo: bar


### PR DESCRIPTION
#### Changes
* Adds the `refresh_config` driver attribute. If truthy, this attribute will cause the driver to run `pulumi config refresh` on the target stack before all calls to `pulumi up`.
* Adds the `Boolean` config attribute schema for accepting Boolean values from a user's `.kitchen.yml` file.
* Adds tests for this feature.