### PR TITLE
Add stack evolution driver attribute for testing stack configuration changes over time

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
+Metrics/ClassLength:
+  Max: 125
 Metrics/MethodLength:
   Max: 15
 Metrics/AbcSize:

--- a/lib/kitchen/pulumi/config_attribute/stack_evolution.rb
+++ b/lib/kitchen/pulumi/config_attribute/stack_evolution.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi/config_attribute'
+require 'kitchen/pulumi/config_schemas/config_evolution_array'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Module used for the 'config_evolution' instance var on an
+      # instance driver. The driver will set the Pulumi stack
+      # configs for each config in the array and then call `pulumi up`
+      # between each item in the evolution list. This has the effect of
+      # testing a user's stack configuration changes over time.
+      module StackEvolution
+        def self.included(plugin)
+          definer = ConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::ConfigEvolutionArray,
+          )
+          definer.define(plugin_class: plugin)
+        end
+
+        def self.to_sym
+          :stack_evolution
+        end
+
+        extend ConfigAttributeCacher
+
+        def config_stack_evolution_default_value
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/pulumi/config_schemas/config_evolution_array.rb
+++ b/lib/kitchen/pulumi/config_schemas/config_evolution_array.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'dry-validation'
+require 'kitchen/pulumi/config_schemas'
+
+module Kitchen
+  module Pulumi
+    ConfigSchemas::ConfigEvolutionArray = ::Dry::Validation.Schema do
+      configure do
+        config.messages_file = "#{__dir__}/error_messages.yml"
+
+        def config_evolution_items_valid_types?(value)
+          return false unless value.is_a?(Hash)
+
+          config_file = value.fetch(:config_file, '')
+          conf = value.fetch(:config, {})
+          secrets = value.fetch(:secrets, {})
+
+          config_file.is_a?(String) && conf.is_a?(Hash) && secrets.is_a?(Hash)
+        end
+
+        def config_evolution_array_item_valid?(value)
+          c_file = value.fetch(:config_file, '')
+          config = value.fetch(:config, {})
+          secrets = value.fetch(:secrets, {})
+
+          c_file_ok = c_file.empty? || File.file?(File.expand_path(c_file))
+          config_valid = config.all? { |_, nested| nested.is_a?(Hash) }
+          secrets_valid = secrets.all? { |_, nested| nested.is_a?(Hash) }
+          c_file_ok && config_valid && secrets_valid
+        end
+      end
+
+      required(:value).each(
+        :config_evolution_items_valid_types?,
+        :config_evolution_array_item_valid?,
+      )
+    end
+  end
+end

--- a/lib/kitchen/pulumi/config_schemas/error_messages.yml
+++ b/lib/kitchen/pulumi/config_schemas/error_messages.yml
@@ -5,3 +5,17 @@ en:
       Invalid stack settings map - config/secrets maps should be a map of maps.
       The top-level map keys represent Pulumi namespaces on which the key-value pairs
       in that namespace's nested map are set.
+
+    config_evolution_items_valid_types?: >
+      Invalid stack evolution list - Stack evolutions must be a list whose map-type items contain at
+      least one of three values --- 1. 'config_file' - String specifying path to config file to use for this update.
+      2. 'config' - A map of maps in which the top-level map keys represent Pulumi namespaces on which the key-value pairs
+      in that namespace's nested map are set. 3. 'secrets' -- A map with the same structure as 'config', but whose values
+      will be set as secrets on your stack.
+
+    config_evolution_array_item_valid?: >
+      Invalid stack evolution list - Stack evolutions must be a list whose map-type items contain at
+      least one of three values --- 1. 'config_file' - String specifying path to config file to use for this update.
+      2. 'config' - A map of maps in which the top-level map keys represent Pulumi namespaces on which the key-value pairs
+      in that namespace's nested map are set. 3. 'secrets' -- A map with the same structure as 'config', but but whose values
+      will be set as secrets on your stack.

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -6,6 +6,7 @@ require 'kitchen/driver/pulumi'
 
 # rubocop:disable Metrics/ParameterLists
 # rubocop:disable Metrics/BlockLength
+# rubocop:disable Metrics/MethodLength
 describe ::Kitchen::Driver::Pulumi do
   let(:stack_name) { "test-stack-#{rand(10**10)}" }
   let(:bucket_name) { 'foo-bucket' }
@@ -35,7 +36,8 @@ describe ::Kitchen::Driver::Pulumi do
                        config: {},
                        config_file: '',
                        secrets: {},
-                       refresh_config: false)
+                       refresh_config: false,
+                       stack_evolution: [])
     driver_config = {
       kitchen_root: kitchen_root,
       directory: directory,
@@ -46,6 +48,7 @@ describe ::Kitchen::Driver::Pulumi do
       config_file: config_file,
       secrets: secrets,
       refresh_config: refresh_config,
+      stack_evolution: stack_evolution,
     }
 
     driver = described_class.new(driver_config)
@@ -115,6 +118,15 @@ describe ::Kitchen::Driver::Pulumi do
         config = { 'test-project': { foo: 'bar' } }
         secrets = { 'test-project': { ssh_key: 'ShouldBeSecret' } }
         config_file = 'custom-stack-config-file.yaml'
+        stack_evolution = [
+          {
+            config: { 'test-project': { foo: 'newfoo' } },
+            secrets: { 'test-project': { ssh_key: 'NewSecret' } },
+          },
+          {
+            config_file: 'stack-evolution.yaml',
+          },
+        ]
 
         driver = configure_driver(
           stack: stack_name,
@@ -122,11 +134,11 @@ describe ::Kitchen::Driver::Pulumi do
           config_file: config_file,
           secrets: secrets,
           refresh_config: true,
+          stack_evolution: stack_evolution,
         )
 
         expected = expect do
           driver.create({})
-          driver.update({})
           driver.update({})
         end
 
@@ -164,3 +176,4 @@ describe ::Kitchen::Driver::Pulumi do
 end
 # rubocop:enable Metrics/ParameterLists
 # rubocop:enable Metrics/BlockLength
+# rubocop:enable Metrics/MethodLength

--- a/spec/support/test-project/.kitchen.yml
+++ b/spec/support/test-project/.kitchen.yml
@@ -15,6 +15,12 @@ suites:
       config:
         test-project:
           foo: bar
+      stack_evolution:
+        - config:
+            test-project:
+              foo: new-value
+        - config_file: custom-stack-config-file.yaml
+
 
   - name: test-project-dev-east
     driver:
@@ -27,6 +33,14 @@ suites:
       secrets:
         test-project:
           ssh_key: foo
+      stack_evolution:
+        - config_file: custom-stack-config-file.yaml
+        - config:
+            test-project:
+              foo: takes-precedence-over-config-file
+          secrets:
+            test-project:
+              access_key: access.pem
 
 platforms:
   - name: default

--- a/spec/support/test-project/stack-evolution.yaml
+++ b/spec/support/test-project/stack-evolution.yaml
@@ -1,4 +1,4 @@
 config:
   aws:region: us-east-1
   test-project:bucket_name: kitchen-pulumi-custom-conf-file
-  test-project:foo: new-value
+  test-project:foo: takes-precedence-over-config-file


### PR DESCRIPTION
#### Changes
* Adds a `stack_evolution` driver config attribute that will be used to effectively test user stack configuration changes over time.
  * This attribute takes a list of maps which may override any of the `config_file`, `config`, and `secrets` set on the driver. The driver will then iterate through this list of evolutions, setting the configs appropriately and then calling `pulumi up` to update the stack with each new configuration.
* Adds a config attribute schema to validate acceptable `stack_evolution` lists from the `.kitchen.yml` file
* Adds unit and integration tests.

##### Example
```yaml
---
driver:
  name: pulumi

provisioner:
  name: pulumi

platforms:
  - name: default

# 'pulumi update' will be called 4 times in total for this Kitchen instance's stack:
#     1. With the first config from initial-stack-config.yaml
#     2. With the config from  updated-security-groups-config.yaml
#     3. With the config from  changed-ec2-ami.yaml
#     4. With the config from  initial-stack-config.yaml with the added/overridden 
#        primary_region and west_specific_key stack configs
suites:
  - name: test-project-dev
    driver:
      stack: test-project-web-stack
      config_file: initial-stack-config.yaml
      stack_evolution:
        - config_file: updated-security-groups-config.yaml
        - config_file: changed-ec2-ami.yaml
        - config:
            test-project:
              primary_region: us-west-2
          secrets:
            test-project:
              west_specific_key: west-key-secret
        
```