### PR TITLE
Fix nonexistent stack handling on local backend

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,4 +14,4 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 15
 Metrics/AbcSize:
-  Max: 16
+  Max: 20

--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -70,7 +70,11 @@ module Kitchen
         login
         ::Kitchen::Pulumi::ShellOut.run(cmd: cmds, logger: logger)
       rescue ::Kitchen::Pulumi::Error => e
-        puts 'Continuing...' if e.message.match?(/no stack named '#{stack}' found/)
+        if e.message.match?(/no stack named '#{stack}' found/) || (
+          e.message.match?(/failed to load checkpoint/) && config_backend == 'local'
+        )
+          puts "Stack '#{stack}' does not exist, continuing..."
+        end
       end
 
       def login

--- a/lib/kitchen/pulumi/config_attribute/backend.rb
+++ b/lib/kitchen/pulumi/config_attribute/backend.rb
@@ -26,7 +26,7 @@ module Kitchen
         extend ConfigAttributeCacher
 
         def config_backend_default_value
-          ''
+          'https://api.pulumi.com'
         end
       end
     end

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -158,10 +158,14 @@ describe ::Kitchen::Driver::Pulumi do
       in_tmp_project_dir('test-project') do
         config = { 'test-project': { bucket_name: bucket_name } }
 
-        driver = configure_driver(stack: stack_name, config: config)
+        driver = configure_driver(
+          stack: stack_name,
+          config: config,
+          backend: 'https://api.pulumi.com',
+        )
 
         expect { driver.destroy({}) }
-          .to output(/no stack named '#{stack_name}' found/)
+          .to output(/Stack '#{stack_name}' does not exist/)
           .to_stdout_from_any_process
 
         expect do


### PR DESCRIPTION
#### Changes
* When `pulumi destroy` is ran on a nonexistent stack using the local backend, the `stack '<stackname>' not found` error does not occur. Rather, an error loading the Checkpoint for the stack occurs. This PR introduces handling of the checkpoint error in the case of destroying nonexistent local stacks.
* Makes the default backend `https://api.pulumi.com`. Recent changes to the Pulumi CLI have changed the behavior of `pulumi login`, so we make sure that the SaaS backend is used by default all the time. See pulumi/pulumi#2926 for more details