### PR TITLE
Redesign Driver to prevent stack config file overrides during testing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Style/TrailingCommaInArguments:
 Metrics/LineLength:
   Max: 90
 Metrics/ClassLength:
-  Max: 125
+  Max: 150
 Metrics/MethodLength:
   Max: 15
 Metrics/AbcSize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 ---
 AllCops:
   TargetRubyVersion: 2.6
+  Exclude:
+    - 'vendor/**/*'
+    - 'lib/kitchen/pulumi/deep_merge.rb'
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 Style/TrailingCommaInArrayLiteral:

--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -75,7 +75,7 @@ module Kitchen
       def stack
         return config_test_stack_name unless config_test_stack_name.empty?
 
-        instance.suite.name
+        "#{instance.suite.name}-#{instance.platform.name}"
       end
 
       def login

--- a/lib/kitchen/pulumi.rb
+++ b/lib/kitchen/pulumi.rb
@@ -4,5 +4,20 @@
 module Kitchen
   # Namespace for Kitchen-Pulumi logic
   module Pulumi
+    def self.with_temp_conf(config_file = '')
+      temp_conf = Tempfile.new(['kitchen-pulumi', '.yaml'])
+
+      if config_file.empty?
+        yield('') if block_given?
+      else
+        begin
+          IO.copy_stream(config_file, temp_conf.path)
+          yield(temp_conf.path) if block_given?
+        ensure
+          temp_conf.close
+          temp_conf.unlink
+        end
+      end
+    end
   end
 end

--- a/lib/kitchen/pulumi/config_attribute/test_stack_name.rb
+++ b/lib/kitchen/pulumi/config_attribute/test_stack_name.rb
@@ -8,8 +8,9 @@ require 'kitchen/pulumi/config_attribute_definer'
 module Kitchen
   module Pulumi
     module ConfigAttribute
-      # Attribute used to specify the stack to use for a specific instance
-      module Stack
+      # Attribute used to override the stack name to use for the stack
+      # created for an instance.
+      module TestStackName
         def self.included(plugin_class)
           definer = ConfigAttributeDefiner.new(
             attribute: self,
@@ -19,12 +20,12 @@ module Kitchen
         end
 
         def self.to_sym
-          :stack
+          :test_stack_name
         end
 
         extend ConfigAttributeCacher
 
-        def config_stack_default_value
+        def config_test_stack_name_default_value
           ''
         end
       end

--- a/lib/kitchen/pulumi/deep_merge.rb
+++ b/lib/kitchen/pulumi/deep_merge.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ::Hash
+  def deep_merge(second)
+    merger = proc { |_key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : Array === v1 && Array === v2 ? v1 | v2 : [:undefined, nil, :nil].include?(v2) ? v1 : v2 }
+    merge(second.to_h, &merger)
+  end
+end

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -30,7 +30,7 @@ describe ::Kitchen::Driver::Pulumi do
 
   def configure_driver(directory: '.',
                        kitchen_root: '.',
-                       stack: '',
+                       test_stack_name: '',
                        backend: '',
                        plugins: [],
                        config: {},
@@ -38,10 +38,16 @@ describe ::Kitchen::Driver::Pulumi do
                        secrets: {},
                        refresh_config: false,
                        stack_evolution: [])
+    test_stack_name = if test_stack_name.empty?
+                        "kitchen-pulumi-test-#{rand(10**10)}"
+                      else
+                        test_stack_name
+                      end
+
     driver_config = {
       kitchen_root: kitchen_root,
       directory: directory,
-      stack: stack.empty? ? "kitchen-pulumi-test-#{rand(10**10)}" : stack,
+      test_stack_name: test_stack_name,
       backend: backend,
       plugins: plugins,
       config: config,
@@ -69,7 +75,7 @@ describe ::Kitchen::Driver::Pulumi do
 
     it 'should allow overrides of the stack name' do
       in_tmp_project_dir('test-project') do
-        driver = configure_driver(stack: stack_name)
+        driver = configure_driver(test_stack_name: stack_name)
         expect { driver.create({}) }
           .to output(/Created stack '#{stack_name}'/).to_stdout_from_any_process
       end
@@ -77,7 +83,7 @@ describe ::Kitchen::Driver::Pulumi do
 
     it 'should allow local backends' do
       in_tmp_project_dir('test-project') do
-        driver = configure_driver(stack: stack_name, backend: 'file://~')
+        driver = configure_driver(test_stack_name: stack_name, backend: 'file://~')
         expect { driver.create({}) }
           .to output(/Created stack '#{stack_name}'/).to_stdout_from_any_process
       end
@@ -85,7 +91,7 @@ describe ::Kitchen::Driver::Pulumi do
 
     it 'should allow local backend with convenient name "local"' do
       in_tmp_project_dir('test-project') do
-        driver = configure_driver(stack: stack_name, backend: 'local')
+        driver = configure_driver(test_stack_name: stack_name, backend: 'local')
         expect { driver.create({}) }
           .to output(/Created stack '#{stack_name}'/).to_stdout_from_any_process
       end
@@ -94,7 +100,7 @@ describe ::Kitchen::Driver::Pulumi do
     it 'should allow custom config files' do
       in_tmp_project_dir('test-project') do
         config_file = 'custom-test-config-file.yaml'
-        driver = configure_driver(stack: stack_name, config_file: config_file)
+        driver = configure_driver(test_stack_name: stack_name, config_file: config_file)
         expect { driver.create({}) }
           .to output(/Created stack '#{stack_name}'/).to_stdout_from_any_process
       end
@@ -104,9 +110,9 @@ describe ::Kitchen::Driver::Pulumi do
       in_tmp_project_dir('test-project') do
         invalid_config = { "test-project": ['must be a hash, not an array'] }
 
-        expect { configure_driver(stack: stack_name, config: invalid_config) }
+        expect { configure_driver(test_stack_name: stack_name, config: invalid_config) }
           .to raise_error(::Kitchen::UserError, /should be a map of maps/)
-        expect { configure_driver(stack: stack_name, secrets: invalid_config) }
+        expect { configure_driver(test_stack_name: stack_name, secrets: invalid_config) }
           .to raise_error(::Kitchen::UserError, /should be a map of maps/)
       end
     end
@@ -129,7 +135,7 @@ describe ::Kitchen::Driver::Pulumi do
         ]
 
         driver = configure_driver(
-          stack: stack_name,
+          test_stack_name: stack_name,
           config: config,
           config_file: config_file,
           secrets: secrets,
@@ -159,7 +165,7 @@ describe ::Kitchen::Driver::Pulumi do
         config = { 'test-project': { bucket_name: bucket_name } }
 
         driver = configure_driver(
-          stack: stack_name,
+          test_stack_name: stack_name,
           config: config,
           backend: 'https://api.pulumi.com',
         )

--- a/spec/support/test-project/.kitchen.yml
+++ b/spec/support/test-project/.kitchen.yml
@@ -15,7 +15,7 @@ platforms:
   - name: test-project-dev-west
     driver:
       backend: local
-      stack: <%= "dev-west-#{rand(10**10)}" %>
+      test_stack_name: <%= "dev-west-#{rand(10**10)}" %>
       config_file: custom-stack-config-file.yaml
       refresh_config: true
       config:
@@ -30,12 +30,11 @@ platforms:
 
   - name: test-project-dev-east
     driver:
-      stack: <%= "dev-west-#{rand(10**10)}" %>
+      test_stack_name: <%= "dev-east-#{rand(10**10)}" %>
+      config_file: dev-east.yaml
       config:
         test-project:
           bucket_name: kitchen-pulumi-9089332077
-        aws:
-          region: us-east-1
       secrets:
         test-project:
           ssh_key: foo

--- a/spec/support/test-project/dev-east.yaml
+++ b/spec/support/test-project/dev-east.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: us-east-1


### PR DESCRIPTION
#### Changes
* Redesigns the driver configuration to prevent permanently overriding intermediate values set on stack configs.
  * kitchen-pulumi will create a copy from the file specified by the new `config_file` driver attribute, which may be any valid YAML file that conforms to the Pulumi stack config file structure.
  * Additionally, the `stack` driver attribute has been removed to make test stack handling more transparent. The new `test_stack_name` is used in its place and represents the value of the stack name to create for a given test. The default stack name is the name of the kitchen instance.
* Updates tests

##### Example driver configuration
```yaml
    driver:
      test_stack_name: dev-east-test           # Name of the test stack will be 'dev-east-test'
      config_file: Pulumi.dev-east.yaml        # Use the stack config for the 'dev-east' stack as a base
      config:
        test-project:
          bucket_name: my-s3-bucket
      secrets:
        test-project:
          ssh_key: <%= ENV['SSH_KEY'] %>
      stack_evolution:
        - config_file: changed_stack_configuration.yaml
        - config:
            test-project:
              foo: takes-precedence-over-config-file
          secrets:
            test-project:
              access_key: <%= ENV['ACCESS_KEY'] %>
```
