### PR TITLE
Use TargetRubyVersion 2.5 for Code Climate scan

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
   Exclude:
     - 'vendor/**/*'
     - 'lib/kitchen/pulumi/deep_merge.rb'


### PR DESCRIPTION
Maintainability scan doesn't support TargetRubyVersion 2.6 yet 😞 