### PR TITLE
Add secrets provider driver attribute

### DIFF
--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -18,6 +18,7 @@ require 'kitchen/pulumi/config_attribute/secrets'
 require 'kitchen/pulumi/config_attribute/test_stack_name'
 require 'kitchen/pulumi/config_attribute/stack_evolution'
 require 'kitchen/pulumi/config_attribute/refresh_config'
+require 'kitchen/pulumi/config_attribute/secrets_provider'
 
 module Kitchen
   module Driver
@@ -37,6 +38,7 @@ module Kitchen
       include ::Kitchen::Pulumi::ConfigAttribute::TestStackName
       include ::Kitchen::Pulumi::ConfigAttribute::StackEvolution
       include ::Kitchen::Pulumi::ConfigAttribute::RefreshConfig
+      include ::Kitchen::Pulumi::ConfigAttribute::SecretsProvider
 
       def create(_state)
         dir = "-C #{config_directory}"
@@ -81,6 +83,14 @@ module Kitchen
         "#{instance.suite.name}-#{instance.platform.name}"
       end
 
+      def secrets_provider(flag: false)
+        return '' if config_secrets_provider.empty?
+
+        return "--secrets-provider=\"#{config_secrets_provider}\"" if flag
+
+        config_secrets_provider
+      end
+
       def login
         backend = config_backend == 'local' ? '--local' : config_backend
         ::Kitchen::Pulumi::ShellOut.run(
@@ -91,7 +101,7 @@ module Kitchen
 
       def initialize_stack(stack, dir = '')
         ::Kitchen::Pulumi::ShellOut.run(
-          cmd: "stack init #{stack} #{dir}",
+          cmd: "stack init #{stack} #{dir} #{secrets_provider(flag: true)}",
           logger: logger,
         )
       rescue ::Kitchen::Pulumi::Error => e

--- a/lib/kitchen/pulumi/config_attribute/secrets_provider.rb
+++ b/lib/kitchen/pulumi/config_attribute/secrets_provider.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi'
+require 'kitchen/pulumi/config_schemas/string'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Attribute used to specify the secrets provider a stack should use
+      module SecretsProvider
+        def self.included(plugin_class)
+          definer = ConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::String,
+          )
+          definer.define(plugin_class: plugin_class)
+        end
+
+        def self.to_sym
+          :secrets_provider
+        end
+
+        extend ConfigAttributeCacher
+
+        def config_secrets_provider_default_value
+          ''
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -37,6 +37,7 @@ describe ::Kitchen::Driver::Pulumi do
                        config_file: '',
                        secrets: {},
                        refresh_config: false,
+                       secrets_provider: '',
                        stack_evolution: [])
     test_stack_name = if test_stack_name.empty?
                         "kitchen-pulumi-test-#{rand(10**10)}"
@@ -54,6 +55,7 @@ describe ::Kitchen::Driver::Pulumi do
       config_file: config_file,
       secrets: secrets,
       refresh_config: refresh_config,
+      secrets_provider: secrets_provider,
       stack_evolution: stack_evolution,
     }
 
@@ -78,6 +80,17 @@ describe ::Kitchen::Driver::Pulumi do
         driver = configure_driver(test_stack_name: stack_name)
         expect { driver.create({}) }
           .to output(/Created stack '#{stack_name}'/).to_stdout_from_any_process
+      end
+    end
+
+    it 'should raise an error when an invalid secrets provider is given' do
+      in_tmp_project_dir('test-project') do
+        driver = configure_driver(
+          test_stack_name: stack_name,
+          secrets_provider: 'awskms://1234abcd-12ab-34cd-56-1234567890?region=us-east-1',
+        )
+        expect { driver.create({}) }
+          .to output(/does not exist/).to_stdout_from_any_process
       end
     end
 

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -90,7 +90,7 @@ describe ::Kitchen::Driver::Pulumi do
           secrets_provider: 'awskms://1234abcd-12ab-34cd-56-1234567890?region=us-east-1',
         )
         expect { driver.create({}) }
-          .to output(/does not exist/).to_stdout_from_any_process
+          .to output(/error/).to_stdout_from_any_process
       end
     end
 


### PR DESCRIPTION
#### Changes
* Adds the `secrets_provider` driver attribute that will be used to specify the [secrets provider](https://www.pulumi.com/docs/intro/concepts/config/#initializing-a-stack-with-alternative-encryption) for a stack, when provided by the user.