### PR TITLE
Add preserve_config driver attribute

### DIFF
--- a/lib/kitchen/driver/pulumi.rb
+++ b/lib/kitchen/driver/pulumi.rb
@@ -19,6 +19,7 @@ require 'kitchen/pulumi/config_attribute/test_stack_name'
 require 'kitchen/pulumi/config_attribute/stack_evolution'
 require 'kitchen/pulumi/config_attribute/refresh_config'
 require 'kitchen/pulumi/config_attribute/secrets_provider'
+require 'kitchen/pulumi/config_attribute/preserve_config'
 
 module Kitchen
   module Driver
@@ -39,6 +40,7 @@ module Kitchen
       include ::Kitchen::Pulumi::ConfigAttribute::StackEvolution
       include ::Kitchen::Pulumi::ConfigAttribute::RefreshConfig
       include ::Kitchen::Pulumi::ConfigAttribute::SecretsProvider
+      include ::Kitchen::Pulumi::ConfigAttribute::PreserveConfig
 
       def create(_state)
         dir = "-C #{config_directory}"
@@ -64,7 +66,7 @@ module Kitchen
 
         cmds = [
           "destroy -y -r --show-config -s #{stack} #{dir}",
-          "stack rm --preserve-config -y -s #{stack} #{dir}",
+          "stack rm #{preserve_config} -y -s #{stack} #{dir}",
         ]
 
         login
@@ -75,6 +77,12 @@ module Kitchen
         )
           puts "Stack '#{stack}' does not exist, continuing..."
         end
+      end
+
+      def preserve_config
+        return '' unless config_preserve_config
+
+        '--preserve-config'
       end
 
       def stack

--- a/lib/kitchen/pulumi/config_attribute/preserve_config.rb
+++ b/lib/kitchen/pulumi/config_attribute/preserve_config.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'kitchen/pulumi'
+require 'kitchen/pulumi/config_schemas/boolean'
+require 'kitchen/pulumi/config_attribute_cacher'
+require 'kitchen/pulumi/config_attribute_definer'
+
+module Kitchen
+  module Pulumi
+    module ConfigAttribute
+      # Attribute used to determine if the stack config should be
+      # preserved after stack is removed with `pulumi stack rm`
+      # during destroy.
+      module PreserveConfig
+        def self.included(plugin_class)
+          definer = ConfigAttributeDefiner.new(
+            attribute: self,
+            schema: ConfigSchemas::Boolean,
+          )
+          definer.define(plugin_class: plugin_class)
+        end
+
+        def self.to_sym
+          :preserve_config
+        end
+
+        extend ConfigAttributeCacher
+
+        def config_preserve_config_default_value
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/kitchen/driver/pulumi_spec.rb
+++ b/spec/lib/kitchen/driver/pulumi_spec.rb
@@ -36,6 +36,7 @@ describe ::Kitchen::Driver::Pulumi do
                        config: {},
                        config_file: '',
                        secrets: {},
+                       preserve_config: false,
                        refresh_config: false,
                        secrets_provider: '',
                        stack_evolution: [])
@@ -54,6 +55,7 @@ describe ::Kitchen::Driver::Pulumi do
       config: config,
       config_file: config_file,
       secrets: secrets,
+      preserve_config: preserve_config,
       refresh_config: refresh_config,
       secrets_provider: secrets_provider,
       stack_evolution: stack_evolution,
@@ -181,6 +183,7 @@ describe ::Kitchen::Driver::Pulumi do
           test_stack_name: stack_name,
           config: config,
           backend: 'https://api.pulumi.com',
+          preserve_config: true,
         )
 
         expect { driver.destroy({}) }

--- a/spec/support/test-project/.kitchen.yml
+++ b/spec/support/test-project/.kitchen.yml
@@ -18,6 +18,7 @@ platforms:
       test_stack_name: <%= "dev-west-#{rand(10**10)}" %>
       config_file: custom-stack-config-file.yaml
       refresh_config: true
+      preserve_config: true
       config:
         test-project:
           foo: bar
@@ -32,6 +33,7 @@ platforms:
     driver:
       test_stack_name: <%= "dev-east-#{rand(10**10)}" %>
       config_file: dev-east.yaml
+      preserve_config: true
       config:
         test-project:
           bucket_name: kitchen-pulumi-9089332077

--- a/spec/support/test-project/test/integration/default/controls/test_control.rb
+++ b/spec/support/test-project/test/integration/default/controls/test_control.rb
@@ -3,17 +3,17 @@
 control 'test_control' do
   describe 'bucket name input and outputs match without prefix' do
     subject do
-      attribute('bucketName')
+      input('bucketName')
     end
 
-    it { should eq attribute('test-project:bucket_name') }
+    it { should eq input('test-project:bucket_name') }
   end
 
   describe 'bucket_name input and outputs match' do
     subject do
-      attribute('output_bucketName')
+      input('output_bucketName')
     end
 
-    it { should eq attribute('input_test-project:bucket_name') }
+    it { should eq input('input_test-project:bucket_name') }
   end
 end

--- a/spec/support/test-project/test/integration/default/inspec.yml
+++ b/spec/support/test-project/test/integration/default/inspec.yml
@@ -1,5 +1,5 @@
 name: default
-attributes:
+inputs:
   - name: input_test-project:bucket_name
     type: string
     required: true


### PR DESCRIPTION
#### Changes
* Adds the `preserve_config` driver attribute which is used to tell kitchen-pulumi whether or not to keep stack configurations after destroy when running `pulumi stack rm`