### PR TITLE
Update stack config values before verification

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,8 +13,8 @@ Style/TrailingCommaInArguments:
 Metrics/LineLength:
   Max: 90
 Metrics/ClassLength:
-  Max: 150
+  Max: 175
 Metrics/MethodLength:
   Max: 15
 Metrics/AbcSize:
-  Max: 20
+  Max: 21


### PR DESCRIPTION
#### Changes
* This change ensures that the stack config values for each instance are up-to-date with the config values used by the last stack update during converge. The effect is that the stack input values to InSpec profiles will be those used by the temporary stack config file created by Kitchen-Pulumi during convergences.